### PR TITLE
Raw print application metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,7 @@ dependencies = [
  "anyhow",
  "clap",
  "spin-common",
+ "spin-locked-app",
  "spin-oci",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2484,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "human_bytes",
+ "serde",
+ "serde_json",
  "spin-common",
  "spin-locked-app",
  "spin-oci",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 
 spin-common = { git = "https://github.com/fermyon/spin" }
 spin-oci = { git = "https://github.com/fermyon/spin" }
+spin-locked-app = { git = "https://github.com/fermyon/spin" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.1.4", features = ["derive"] }
+human_bytes = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tempfile = "3.8.0"
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tempfile = "3.8.0"
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
+walkdir = "2"
 
 spin-common = { git = "https://github.com/fermyon/spin" }
 spin-oci = { git = "https://github.com/fermyon/spin" }


### PR DESCRIPTION

```
$ spin info -f ghcr.io/radu-matei/perftest:v1
Getting info for app "ghcr.io/radu-matei/perftest:v1"
Application metadata:
      authors: ["Radu Matei <radu@fermyon.com>"]
      name: "perftest"
      origin: "vnd.fermyon.origin-oci:ghcr.io/radu-matei/perftest:v1"
      trigger: {"base":"/","type":"http"}
      triggers: {"http":{"base":"/"}}
      version: "0.1.0"
Trigger: LockedTrigger { id: "trigger-perftest", trigger_type: "http", trigger_config: Object {"component": String("perftest"), "route": String("/...")} }
Variables: {}
Host Requirements: {}
LockedComponent { id: "perftest", metadata: {"allowed_outbound_hosts": Array [String("redis://*:*"), String("mysql://*:*"), String("postgres://*:*")], "build": Object {"command": String("cargo build --target wasm32-wasi --release"), "watch": Array [String("src/**/*.rs"), String("Cargo.toml")]}}, source: LockedComponentSource { content_type: "application/wasm", content: ContentRef { source: Some("file:///Users/radu/Library/Caches/spin/registry/wasm/sha256:dc2c7470a3044c47ae9f78428f30023e9a7bcc1f949dea0801ea3d2351ed85dc"), inline: None, digest: None } }, env: {}, files: [], config: {} }
```