### PR TITLE
added comfy-table feature to spin-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
+dependencies = [
+ "crossterm",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +592,28 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.5.0",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -650,8 +684,8 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "sha2",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "tar",
  "thiserror",
  "tokio",
@@ -2484,6 +2518,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "comfy-table",
  "human_bytes",
  "serde",
  "serde_json",
@@ -2655,6 +2690,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2706,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3156,6 +3210,12 @@ name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 walkdir = "2"
+comfy-table = "7.1.1"
 
 spin-common = { git = "https://github.com/fermyon/spin" }
 spin-oci = { git = "https://github.com/fermyon/spin" }


### PR DESCRIPTION
Hey @radu-matei 
I added this small feature to spin-info. 

```console
$ ./target/debug/spin-info -f ghcr.io/radu-matei/perftest:v1
Getting info for app "ghcr.io/radu-matei/perftest:v1"
Application Info:
+----------+---------------------------------------------------------+
| Key      | Value                                                   |
+====================================================================+
| authors  | ["Radu Matei <radu@fermyon.com>"]                       |
|----------+---------------------------------------------------------|
| name     | "perftest"                                              |
|----------+---------------------------------------------------------|
| origin   | "vnd.fermyon.origin-oci:ghcr.io/radu-matei/perftest:v1" |
|----------+---------------------------------------------------------|
| trigger  | {"base":"/","type":"http"}                              |
|----------+---------------------------------------------------------|
| triggers | {"http":{"base":"/"}}                                   |
|----------+---------------------------------------------------------|
| version  | "0.1.0"                                                 |
+----------+---------------------------------------------------------+
Application will be triggered by:
   * http trigger: trigger-perftest: {"component":"perftest","route":"/..."}
Component perftest
Component Information:
+--------------------------+------------------------------------------------+
| Field                    | Value                                          |
+===========================================================================+
| Description              | None                                           |
|--------------------------+------------------------------------------------|
| Allowed Outbound Hosts   | ["redis://*:*","mysql://*:*","postgres://*:*"] |
|--------------------------+------------------------------------------------|
| Allowed Key/Value Stores | []                                             |
|--------------------------+------------------------------------------------|
| Allowed Databases        | []                                             |
|--------------------------+------------------------------------------------|
| Allowed AI Models        | None                                           |
|--------------------------+------------------------------------------------|
| Build Command            | cargo build --target wasm32-wasi --release     |
+--------------------------+------------------------------------------------+
   The source for component perftest
      * content type: application/wasm
      * file size: 2.1 MiB
```